### PR TITLE
웹훅 API status가 200인데도 db에 저장되지않는 이슈 테스트

### DIFF
--- a/src/app/api/tallyFormWebhook/route.ts
+++ b/src/app/api/tallyFormWebhook/route.ts
@@ -69,7 +69,7 @@ export const POST = async (req: NextRequest) => {
     if (tallyFormSignatureKey === checkSignature) {
       if (webhookPayload.eventType === "FORM_RESPONSE") {
         // 날짜 관련 로깅
-        const date = new Date(webhookPayload.createdAt);
+        const date = new Date();
         const yearMonth = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
         const day = String(date.getDate());
 


### PR DESCRIPTION
## 웹훅 API status가 200인데도 db에 저장되지않는 이슈 테스트
Vercel 서버는 UTC 기준으로 작동하기 때문에, 날짜가 13일이어야 하지만 12일로 출력된 것으로 보입니다. 이로 인해 DB에 저장되는 값도 12일로 기록된 것 같습니다.